### PR TITLE
Update parser_download.py

### DIFF
--- a/molencoder/cli/parser_download.py
+++ b/molencoder/cli/parser_download.py
@@ -6,7 +6,7 @@ DEFAULTS = {
         "outfile": "data/chembl22.h5"
     },
     "zinc12": {
-        "uri": "http://zinc.docking.org/db/bysubset/13/13_prop.xls",
+        "uri": "http://zinc12.docking.org/db/bysubset/13/13_prop.xls",
         "outfile": "data/zinc12.h5"
     }
 }


### PR DESCRIPTION
Fixed the url for zinc12